### PR TITLE
Fix ngGirls Banner image on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Este tutorial é código aberto (open source) e foi escrito pela comunidade Angu
 
 Este tutorial é usado nos workshops do [ngGirls](http://ng-girls.org) do Brasil e do mundo. Caso tenha interesse em levar o evento ngGirls para a sua cidade ou caso tenha alguma sugestão para fazer, entre em contato com a gente através do e-mail [info@ng-girls.org](/mailto:info@ng-girls.org).
 
-![](/assets/ngGirls banner transparent.png)
+![](/assets/ngGirls%20banner%20transparent.png)
 
 ![](/assets/slogen.png)
 


### PR DESCRIPTION
the ngGirls's banner was not showing because of the path of the image wasn't being found within GitHub

I've just replaced the space characters in the image path to the '%20' character code

Ps.: The second change in the code (line 17) was made by the GitHub Text Editor, no changes ware made in the text by itself